### PR TITLE
Fix the remote URL to use the github-keygen key

### DIFF
--- a/_posts/2014-01-10-github-accounts.markdown
+++ b/_posts/2014-01-10-github-accounts.markdown
@@ -25,7 +25,7 @@ rm -Rf github-keygen
 Next you'll have to change the remote URL for your git repository so that the ssh config will pick the right key. Just change any `github.com` to `username.github.com`:
 
 {% highlight text %}
-git remote remote set-url https://treydavis.github.com/treydavis/treydavis.github.io.git/
+git remote origin set-url treydavis.github.com:treydavis/treydavis.github.io.git
 {% endhighlight %}
 
 Now your `git push` should work again.


### PR DESCRIPTION
Fix the remote URL to use the SSH link with the github-keygen generated key instead of https:// that doesn't use it at all.

Note: I'm the author of [github-keygen](https://github.com/dolmen/github-keygen).
